### PR TITLE
Removes php X-Powered-By

### DIFF
--- a/root/app/.htaccess
+++ b/root/app/.htaccess
@@ -1,3 +1,4 @@
 RewriteEngine On
 RewriteRule ^(.*)\/random[0-9]+x([0-9]+).jpg$ $1/random.php?jpgsize=$2&%{QUERY_STRING} [L]
 Options FollowSymLinks
+Header unset 'X-Powered-By'


### PR DESCRIPTION
In order to hide php version, adds `Header unset 'X-Powered-By'` to .htaccess file

This could also be done with a script, like the port script, that would change

`expose_php = On` to `expose_php = Off` in /etc/php7/php.ini